### PR TITLE
增加一个扩展选项

### DIFF
--- a/src/Ocelot.Provider.Nacos/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Nacos/OcelotBuilderExtensions.cs
@@ -9,12 +9,15 @@ namespace Ocelot.Provider.Nacos
 {
     public static class OcelotBuilderExtensions
     {
-        public static IOcelotBuilder AddNacosDiscovery(this IOcelotBuilder builder, string section = "nacos")
+        public static IOcelotBuilder AddNacosDiscovery(this IOcelotBuilder builder, IConfiguration configuration, string section = "nacos")
         {
-            builder.Services.AddNacosAspNet(builder.Configuration, section);
+            builder.Services.AddNacosAspNet(configuration, section);
             builder.Services.AddSingleton<ServiceDiscoveryFinderDelegate>(NacosProviderFactory.Get);
             builder.Services.AddSingleton<OcelotMiddlewareConfigurationDelegate>(NacosMiddlewareConfigurationProvider.Get);
             return builder;
         }
+        
+        public static IOcelotBuilder AddNacosDiscovery(this IOcelotBuilder builder, string section = "nacos")
+            => AddNacosDiscovery(builder, builder.Configuration, section);
     }
 }


### PR DESCRIPTION
· 原扩展因为无法提供自定义的configuration参数，导致如果提供了自定义的Ocelot配置，Nacos的配置项必须在Ocelot的配置节点同级目录下，如：
``` json
{
    "Gateways": {
        "GlobalConfiguration": {
            ...
        },
        "Routes": [
            ...
        ],
        "Nacos": {
            ...
        }
    }
}
```
``` csharp
services.AddOcelot(gatewaysConfiguration).AddNacosDiscovery("Nacos");
```
· 新的扩展方法可以分离两个配置，并且更方便Ocelot的配置动态从Nacos获取，如：
``` json
{
    "Nacos": {
        ...
    },
    // 以下配置在Nacos中配置
    "Gateways": {
        "GlobalConfiguration": {
            ...
        },
        "Routes": [
            ...
        ]
    }
}
```
``` csharp
var rootConfiguration;
var nacosConfiguration; // 从Nacos获取
services.AddOcelot(nacosConfiguration.GetConfiguration("Gateways")).AddNacosDiscovery(rootConfiguration, "Nacos");
```